### PR TITLE
Making rpanel work in R 3.1

### DIFF
--- a/R/button.r
+++ b/R/button.r
@@ -1,51 +1,58 @@
+w.button <- function(parent, action = I, title = deparse(substitute(action)), 
+                     repeatdelay = 0, repeatinterval = 0, pos = NULL, 
+                     foreground = NULL, background = NULL, font = NULL) {
+   widget <- w.createwidget(parent, pos, background)
+   widget$.type <- "button"
+   f <- function(...) action()
+   widget$.widget <- handshake(tkbutton, parent$.handle, text=title, command=f, 
+                               repeatdelay=repeatdelay, repeatinterval=repeatinterval)
+   w.appearancewidget(widget, font, foreground, background)
+   invisible(widget)
+}
+
 rp.button <- function(panel, action, title=deparse(substitute(action)), 
                       repeatdelay = 0, repeatinterval = 0, quitbutton = FALSE, 
                       pos = NULL, foreground = NULL, background = NULL, font = NULL,
                       parentname = deparse(substitute(panel)), 
                       name = paste("button", .nc(), sep = ""), ...) {
 
-   if (!exists(panel$panelname, .rpenv, inherits = FALSE))
-     panelname <- deparse(substitute(panel))
-   else
-     panelname <- panel$panelname
+  if (!exists(panel$panelname, .rpenv, inherits = FALSE)) {# if the panelname is not set then
+    panelname = deparse(substitute(panel)) # the panel name should be the panel deparse subst'ed
+# 13/03/2012 these lines are not commented out in previous version
+#    panel <- rp.control.get(panelname, panel) # now get the panel
+#    panel$panelname = panelname # now set the panelname properly
+#    assign(panelname, panel, envir=.rpenv) # now send back the panel
+  } 
+  else { 
+    panelname = panel$panelname 
+# 13/03/2012 these lines are not commented out in previous version
+#    panel <- rp.control.get(panelname, panel) # now get the panel
+  }
   
-   if (is.null(pos) && (length(list(...)) > 0)) pos <- list(...)
+  if (is.null(pos)) { if (length(list(...))) { pos <- list(...) } }
 
-   f <- function() {
-     panel <- rp.control.get(panelname)
-     panel <- action(panel)
-     rp.control.put(panelname, panel)
-     if (quitbutton) {
-       rp.control.dispose(panel)
-       # if (exists(paste(panelname,"$.handle", sep = ""), envir = .rpenv)) 
-       #    eval(parse(text=paste("try(tkdestroy(", panelname, "$.handle))",
-       #    sep="")), envir=.rpenv)
-     }
-   }
+  f <- function()
+  {
+    panel <- rp.control.get(panelname)
+    panel <- action(panel)
+    rp.control.put(panelname, panel)
+  }
 
-   if (rp.widget.exists(panelname, parentname)) 
-      parent <- rp.widget.get(panelname, parentname) 
-   else 
-      parent <- panel
-   if (is.list(pos) && (!is.null(pos$grid)))
-      parent <- rp.widget.get(panelname, pos$grid)
+  if (rp.widget.exists(panelname, parentname)) 
+  { 
+    parent <- rp.widget.get(panelname, parentname) 
+  }
+  else 
+  { 
+    parent <- panel 
+  }
+  if (is.list(pos)) { if (!is.null(pos$grid)) { parent <- rp.widget.get(panelname, pos$grid) } }
 
-   widget <- w.button(parent, f, title, repeatdelay, repeatinterval, pos,
-                      foreground, background, font)
-   rp.widget.put(panelname, name, widget)
+  widget <- w.button(parent, f, title, repeatdelay, repeatinterval, pos, foreground, background, font)
+  rp.widget.put(panelname, name, widget)
 
-   if (.rpenv$savepanel) rp.control.put(panelname, panel)
-   invisible(panelname)
-}
-
-w.button <- function(parent, action = I, title = deparse(substitute(action)), 
-                     repeatdelay = 0, repeatinterval = 0, pos = NULL, 
-                     foreground = NULL, background = NULL, font = NULL) {
-   widget         <- w.createwidget(parent, pos, background)
-   widget$.type   <- "button"
-   f              <- function(...) action()
-   widget$.widget <- handshake(tkbutton, parent$.handle, text=title, command=f, 
-                               repeatdelay=repeatdelay, repeatinterval=repeatinterval)
-   w.appearancewidget(widget, font, foreground, background)
-   invisible(widget)
+  if (.rpenv$savepanel) { rp.control.put(panelname, panel) } # put the panel back into the environment
+  
+  
+  invisible(panelname)
 }

--- a/R/timer.r
+++ b/R/timer.r
@@ -59,8 +59,12 @@ rp.block <- function(panel) {
     panelname <- deparse(substitute(panel))
   else 
     panelname <- panel$panelname
-
-  open <- eval(parse(text=paste("!is.null(",panelname, ")", sep="")), envir=.rpenv)
+  if (exists(panelname, envir= .rpenv)) {
+    open <- eval(parse(text=paste("!is.null(",panelname, ")", sep="")), envir=.rpenv)
+  }
+  else {
+    open <- false
+  }
   while(open) {
     Sys.sleep(0.01)
     # The commented code was added in 1.1-2 but seems to cause a problem
@@ -68,9 +72,16 @@ rp.block <- function(panel) {
     # if (open) {
       open <- exists(panelname, envir= .rpenv)
       if (open)
-        open <- eval(parse(text=paste("!is.null(",panelname, ")", sep="")), envir=.rpenv)
+        tryCatch({
+          open <- eval(parse(text=paste("!is.null(",panelname, ")", sep="")), envir=.rpenv)
+        },
+        error = function(cond) { 
+          message("An error occurred")
+          open <- F
+        })
     # }
   }
 
   invisible()
 }
+

--- a/R/window.r
+++ b/R/window.r
@@ -1,87 +1,4 @@
-rp.control <- function(title = "", size=c(100, 100),
-                 panelname = paste("window", .nc(), sep = ""),
-                 background = NULL, ...) {
-
-  panel <- w.window(title, size, background, panelname, ftype = "old", ...)  
-  panel$panelname <- panelname
-
-  # handshake(tkbind, panel$.handle, "<Destroy>", 
-    # function() {
-      
-      # # rp.control.dispose(panel)
-      
-      # if (!exists(panelname, envir = .rpenv)) return(invisible())
-
-      # if (exists(paste(panelname,"$.handle", sep = ""), envir = .rpenv)) 
-         # eval(parse(text=paste("try(tkdestroy(", panelname, "$.handle))", sep="")),
-              # envir=.rpenv)
-              
-      # listing <- ls(.rpenv)
-      # np      <- nchar(panelname)
-      # for(i in 1:length(listing)) {
-         # if ((listing[i] == panelname) | 
-             # ((substr(listing[i], 1, np) == panelname) & 
-                # (substr(listing[i], np + 1, np + 1) %in% c("$", "."))))
-            # eval(parse(text = paste("remove('", listing[i], "')", sep = "")),
-                         # envir = .rpenv)
-      # }
-      # listing <- ls(.rpenv)
-      
-      # # print("panelname")
-      # # print(panelname)
-      # # print("starting listing")
-      # # # find other examples and set them to NULL
-      # # listing <- ls(.rpenv)
-      # # print(listing)
-      # # for(i in 1:length(listing)) {
-        # # objname <- listing[i]
-        # # print(objname)
-        # # if ((nchar(objname) < 50)) {
-          # # obj <- eval(parse(text=objname), envir=.rpenv)
-          # # if (is.list(obj) && !is.null(obj$.type) && (obj$.type == "window") &&
-              # # as.character(obj$.handle$ID) == as.character(panel$.handle$ID)) {
-                  # # eval(parse(text = paste("remove(", objname, ")", sep = "")),
-                         # # envir = .rpenv)
-                  # # print("deleted")
-          # # }
-        # # }
-      # # }
-      # # listing <- ls(.rpenv)
-      # # print(listing)
-      # # print("finishing listing")
-      
-      # if (exists(panelname, envir = .rpenv)) 
-         # eval(parse(text=paste(panelname, " <- NULL", sep="")), envir=.rpenv)
-
-    # }
-  # )    
-  
-  assign(panelname, panel, .rpenv)
-
-  invisible(panel)
-}
-
-rp.control.dispose <- function(panel) {
-  panelname <- panel$panelname
-  pwidget   <- eval(parse(text = panelname), envir=.rpenv)
-  w.window.dispose(pwidget)
-}
-
-w.window.dispose <- function(panel) try(tkdestroy(panel$.handle))
-
-rp.panel <- function(panelname) {
-# return a panel - with panelname return the named panel, and without the most recently worked with.
-  invisible(rp.control.get(panelname))
-}
-
-rp.control.resize <- function(panel, width, height) {
-  wm <- panel$.handle
-  geo <- paste(width, "x", height, "+", 0, "+", 0, sep="")
-  handshake(tkwm.geometry, wm, geo) 
-}
-
-w.window <- function(title = "", size = c(100, 100), background = NULL,
-                     ftype = "new", ...) {
+w.window <- function(title = "", size = c(100, 100), background = NULL, ftype = "new", ...) {
 
   if (!is.null(size)) { 
     if (length(size) == 2)
@@ -94,7 +11,6 @@ w.window <- function(title = "", size = c(100, 100), background = NULL,
   }
   else
      wm <- handshake(tktoplevel)
-     
   handshake(tkwm.title, wm, title)
   w.setbackground(wm, background)
   if (ftype != "new")
@@ -109,11 +25,85 @@ w.window <- function(title = "", size = c(100, 100), background = NULL,
   invisible(panel)
 }
 
-w.window.settitle <- function(panel, title)  {
+w.window.settitle <- function(panel, title)
+{
   handshake(tkwm.title, panel$handle, title)
   panel$.title <- title
   invisible(panel)
 }
 
+w.window.dispose <- function(panel)
+{
+  try(handshake(tkdestroy, panel$.handle), silent = TRUE)
+}
+
 w.window.focus <- function(panel)
-   handshake(tkfocus, panel$.handle)
+{
+  handshake(tkfocus, panel$.handle)
+}
+
+rp.control <- function(title = "", size=c(100, 100), 
+                       panelname = paste("window", .nc(), sep = ""), background = NULL, ...) {
+  panel <- w.window(title, size, background, panelname, ftype = "old", ...)  
+  panel$panelname <- panelname
+
+  handshake(tkbind, panel$.handle, "<Destroy>", 
+    function() 
+    {  
+# destroy the window
+# this probably should be through 'handshake' but I feel there is a risk it may not work properly every time
+      if (exists(paste(panelname,"$.handle", sep = ""), envir = .rpenv)) 
+         eval(parse(text=paste("try(tkdestroy(", panelname, "$.handle))", sep="")), envir=.rpenv)
+
+# find other examples and set them to NULL
+      listing <- ls(.rpenv)
+      for(i in 1:length(listing)) {
+        objname <- listing[i]
+        if (nchar(objname) < 50) {
+          obj <- eval(parse(text=objname), envir=.rpenv)
+          if (is.list(obj)) {
+            if (!is.null(obj$.type)) {
+              if (obj$.type == "window") {
+                if (as.character(obj$.handle$ID) == as.character(panel$.handle$ID)) {
+                  eval(parse(text = paste("remove(", objname, ")", sep = "")), envir = .rpenv)
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (exists(panelname, envir = .rpenv)) 
+         eval(parse(text=paste(panelname, " <- NULL", sep="")), envir=.rpenv)
+    }
+  )    
+  
+  assign(panelname, panel, .rpenv)
+
+  invisible(panel)
+}
+
+# I'm not sure this function is ever used.  It doesn't look right anyway.  name is never used.
+rp.control.dispose <- function(panel, name)
+{
+  try({
+    panelname <- deparse(substitute(panel))
+    pwidget   <- eval(parse(text = panelname), envir=.rpenv)
+    w.window.dispose(pwidget)
+  })
+}
+
+
+
+
+rp.panel <- function(panelname) {
+# return a panel - with panelname return the named panel, and without the most recently worked with.
+  invisible(rp.control.get(panelname))
+}
+
+rp.control.resize <- function(panel, width, height)
+{
+  wm <- panel$.handle
+  geo <- paste(width, "x", height, "+", 0, "+", 0, sep="")
+  handshake(tkwm.geometry, wm, geo) 
+}


### PR DESCRIPTION
Fixing rpanel to work with R 3.1. The rp.block method did not work anymore, stuck in the while loop when closing a window.
